### PR TITLE
🐛 Removed `exceptionally` from file `FromKafkaToCamunda.java`. This i…

### DIFF
--- a/src/main/java/io/berndruecker/example/camunda/kafka/FromKafkaToCamunda.java
+++ b/src/main/java/io/berndruecker/example/camunda/kafka/FromKafkaToCamunda.java
@@ -35,10 +35,7 @@ public class FromKafkaToCamunda {
       zeebe.newPublishMessageCommand()
         .messageName("MsgKafkaRecordReceived")
         .correlationKey(correlationId)
-        .send()
-        .exceptionally(t -> {
-          throw new RuntimeException("Could not hand over record to Zeebe: "+content+". check nested exception for details: " + t.getMessage());
-        });
+        .send();
   }
 
 }


### PR DESCRIPTION
…s because in async code even though the exception is thrown within `exceptionally`, by the time the exception callback occurs, the calling responsible thread could be already completed.